### PR TITLE
Added Message-Board To View All Messages

### DIFF
--- a/beyond_tutorial/urls.py
+++ b/beyond_tutorial/urls.py
@@ -15,7 +15,10 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+from msgboard import views
+
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('', views.board, name='board')
 ]

--- a/msgboard/templates/msgboard/board.html
+++ b/msgboard/templates/msgboard/board.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>Beyond message board</title>
+        <style type ="text/css">
+            .author, .eom { color: grey }
+        </style>
+    </head>
+    <body>
+        <h1>Beyond message board</h1>
+        {% for message in messages %}
+        <div class="message">
+            <p class="author">
+                Posted by {{message.author}} at {{message.date}}            
+            </p>
+            <p>{{message.text}}</p>
+        </div>
+        {% endfor %}
+        <p class="EOM">(End of messages)</p>    
+    </body>
+</html>

--- a/msgboard/views.py
+++ b/msgboard/views.py
@@ -1,0 +1,7 @@
+from django.shortcuts import render
+from .models import Message
+
+
+def board(request):
+    messages = Message.objects.order_by('-date')
+    return render(request, 'msgboard/board.html', {'messages': messages})


### PR DESCRIPTION
- **Templates**
    Created a new *HTML* template of [board.html](msgboard/templates/msgboard/board.html)
    that displays all the *message* records
    present in the database.
    > Implemented with the help of the *message
    > models*.
- **Views**
    Set the `''` context-path (the main page), to
    display [board.html](msgboard/templates/msgboard/board.html).